### PR TITLE
Update unexpected-check to 1.10.0 and use the built-in 'when fuzzed by' assertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "chance-generators": "1.15.2",
     "mocha": "^2.1.0",
     "unexpected": "10.15.0",
-    "unexpected-check": "1.8.0"
+    "unexpected-check": "1.10.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -143,13 +143,6 @@ describe('exif-reader', function() {
 describe('fuzz tests', function () {
   this.timeout(60000);
 
-  expect.addAssertion('<any> [when] fuzzed by <function> <assertion>', function (expect, subject, generator) {
-    expect.errorMode = 'nested';
-    return expect(function (value) {
-        return expect.shift(value);
-    }, 'to be valid for all', generator(subject));
-  })
-
   expect.addAssertion('<Buffer> to either parse or throw documented error', function (expect, subject) {
     expect.errorMode = 'nested';
     var startTime = Date.now();


### PR DESCRIPTION
I upstreamed the 'when fuzzed by' assertion.
